### PR TITLE
feat: can read config from project directory

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,14 @@
-import { readFileSync } from 'fs';
+import { existsSync, lstatSync, readFileSync } from 'fs';
 import { homedir } from 'os';
+import merge from 'lodash/merge';
 
-const string = readFileSync(`${homedir()}/create-pr.json`).toString();
-const object = JSON.parse(string);
+const readConfig = (path) => {
+  const valid = existsSync(path) && lstatSync(path).isFile();
+  const string = valid ? readFileSync(path).toString() : '{}';
+  return JSON.parse(string);
+};
 
-export default object;
+const globalConfig = readConfig(`${homedir()}/create-pr.json`);
+const currentConfig = readConfig(`${process.cwd()}/create-pr.json`);
+
+export default merge({}, globalConfig, currentConfig);


### PR DESCRIPTION
The global configuration file defined in `~/create-pr.json` can be overridden by a `create-pr.json` file in the current working directory (usually the project where the user is creating the PR). The two configuration files are deeply merged.