### PR TITLE
feat: can read config from project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ Generate a Slack token from [this url](https://api.slack.com/custom-integrations
 ## Usage
 
 In the project directory run `sme-create-pr`. You must follow a specific naming conventions for Git branches in order for this to work. That is `developerName/sprint|bug/trelloCardNumber`.
+
+### Per-project configuration
+You can create another `create-pr.json` file in your project directory, with configurations you want to override.
+
+For instance, let's assume you globally merge PRs into `developers` branch but for one specific project you need to merge PRs into the `master` branch. Then you create a `create-pr.json` file in your project directory with the following content.
+
+``` json
+{
+  "codeCommit": {
+    "targetBranch": "master"
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "create-pr",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sme-create-pr",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Command line tool for creating pull requests on CodeCommit",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
The global configuration file defined in `~/create-pr.json` can be overridden by a `create-pr.json` file in the current working directory (usually the project where the user is creating the PR). The two configuration files are deeply merged.